### PR TITLE
Updated plotters version to fix RGBColor issue.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ hmac = "0.12"
 sha2 = "0.10"
 bincode = "1.3"
 dotenvy = "0.15"
-plotters = "0.3"
-plotters-bitmap = "0.3"
+plotters = "0.3.5"
+plotters-bitmap = "0.3.3"
 image = { version = "0.24", features = ["png"] }
 candle = { version = "0.4", package = "candle-core" }
 candle-nn = { version = "0.4" }


### PR DESCRIPTION
   Compiling rust-slackbot-llm v0.1.0 (/home/nathan/rust-slackbot-llm)
error[E0277]: the trait bound `RGBColor: Into<ShapeStyle>` is not satisfied
   --> src/routes/pages.rs:257:74
    |
257 |             .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], RED));
    |                              ----------------                            ^^^ the trait `Into<ShapeStyle>` is not implemented for `RGBColor`
    |                              |
    |                              required by a bound introduced by this call
    |
    = note: required for `RGBColor` to implement `Into<ShapeStyle>`
note: required by a bound in `plotters::element::PathElement::<Coord>::new`
   --> /home/nathan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/plotters-0.3.0/src/element/basic_shapes.rs:75:40
    |
75  |     pub fn new<P: Into<Vec<Coord>>, S: Into<ShapeStyle>>(points: P, style: S) -> Self {
    |                                        ^^^^^^^^^^^^^^^^ required by this bound in `PathElement::<Coord>::new`
help: consider borrowing here
    |
257 |             .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &RED));
    |                                                                          +

error[E0277]: the trait bound `RGBColor: Into<ShapeStyle>` is not satisfied
   --> src/routes/pages.rs:265:74
    |
265 |             .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], GREEN));
    |                              ----------------                            ^^^^^ the trait `Into<ShapeStyle>` is not implemented for `RGBColor`
    |                              |
    |                              required by a bound introduced by this call
    |
    = note: required for `RGBColor` to implement `Into<ShapeStyle>`
note: required by a bound in `plotters::element::PathElement::<Coord>::new`
   --> /home/nathan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/plotters-0.3.0/src/element/basic_shapes.rs:75:40
    |
75  |     pub fn new<P: Into<Vec<Coord>>, S: Into<ShapeStyle>>(points: P, style: S) -> Self {
    |                                        ^^^^^^^^^^^^^^^^ required by this bound in `PathElement::<Coord>::new`
help: consider borrowing here
    |
265 |             .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &GREEN));
    |                                                                          +

error[E0277]: the trait bound `RGBColor: Into<ShapeStyle>` is not satisfied
   --> src/routes/pages.rs:275:74
    |
275 |             .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], BLUE));
    |                              ----------------                            ^^^^ the trait `Into<ShapeStyle>` is not implemented for `RGBColor`
    |                              |
    |                              required by a bound introduced by this call
    |
    = note: required for `RGBColor` to implement `Into<ShapeStyle>`
note: required by a bound in `plotters::element::PathElement::<Coord>::new`
   --> /home/nathan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/plotters-0.3.0/src/element/basic_shapes.rs:75:40
    |
75  |     pub fn new<P: Into<Vec<Coord>>, S: Into<ShapeStyle>>(points: P, style: S) -> Self {
    |                                        ^^^^^^^^^^^^^^^^ required by this bound in `PathElement::<Coord>::new`
help: consider borrowing here
    |
275 |             .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &BLUE));
    |                                                                          +

error[E0277]: the trait bound `RGBAColor: Into<ShapeStyle>` is not satisfied
   --> src/routes/pages.rs:279:31
    |
279 |             .background_style(WHITE.mix(0.8))
    |              ---------------- ^^^^^^^^^^^^^^ the trait `Into<ShapeStyle>` is not implemented for `RGBAColor`
    |              |
    |              required by a bound introduced by this call
    |
    = note: required for `RGBAColor` to implement `Into<ShapeStyle>`
note: required by a bound in `SeriesLabelStyle::<'a, 'b, DB, CT>::background_style`
   --> /home/nathan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/plotters-0.3.0/src/chart/series.rs:156:32
    |
156 |     pub fn background_style<S: Into<ShapeStyle>>(&mut self, style: S) -> &mut Self {
    |                                ^^^^^^^^^^^^^^^^ required by this bound in `SeriesLabelStyle::<'a, 'b, DB, CT>::background_style`
help: consider borrowing here
    |
279 |             .background_style(&WHITE.mix(0.8))
    |                               +

error[E0277]: the trait bound `RGBColor: Into<ShapeStyle>` is not satisfied
   --> src/routes/pages.rs:280:27
    |
280 |             .border_style(BLACK)
    |              ------------ ^^^^^ the trait `Into<ShapeStyle>` is not implemented for `RGBColor`
    |              |
    |              required by a bound introduced by this call
    |
    = note: required for `RGBColor` to implement `Into<ShapeStyle>`
note: required by a bound in `SeriesLabelStyle::<'a, 'b, DB, CT>::border_style`
   --> /home/nathan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/plotters-0.3.0/src/chart/series.rs:149:28
    |
149 |     pub fn border_style<S: Into<ShapeStyle>>(&mut self, style: S) -> &mut Self {
    |                            ^^^^^^^^^^^^^^^^ required by this bound in `SeriesLabelStyle::<'a, 'b, DB, CT>::border_style`
help: consider borrowing here
    |
280 |             .border_style(&BLACK)
